### PR TITLE
Ignore ui folder for linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      - name: Ignore ui folder by removing it
+        run: rm -rf ./ui        
       - name: GitHub Super Linter
         uses: docker://github/super-linter:v3.2.0
         env:


### PR DESCRIPTION
PR to make everyone happier. Less red crosses. Yay!
Details:
Super-linter cannot ignore folders/files. The easiest way is to remove them. 