### PR TITLE
Change default production host to self

### DIFF
--- a/ui/ui/README.md
+++ b/ui/ui/README.md
@@ -9,12 +9,15 @@ User interface of Evidence.
 - Open: [http://localhost:3000](http://localhost:3000)
 
 ### First time
+
 - Run in ./ui: `npm install`
 
 ## Build
+
 - Use Dockerfile, one level up.
-- When react app runs on a location which is not `http://localhost:8080`: 
-  set host with env var `REACT_APP_HOST`
+- When React app and Go web service (one level up) are not being hosted from same web server then
+  set host of Go web service with env var `REACT_APP_HOST` when building React app Docker image.
 
 ## React Starter App
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/ui/ui/src/config.tsx
+++ b/ui/ui/src/config.tsx
@@ -1,7 +1,7 @@
 import {MoreLikeThisType} from "./app/configuring/MoreLikeThisType";
 
 const prod = {
-    HOST: process.env.REACT_APP_HOST ? process.env.REACT_APP_HOST : 'http://localhost:8080',
+    HOST: process.env.REACT_APP_HOST ? process.env.REACT_APP_HOST : '',
     MORE_LIKE_THIS_SIZE: 10,
     SEARCH_RESULTS_SIZE: 10,
     POSITIVE_SIZE: 10,


### PR DESCRIPTION
As `http://localhost:8080/users` was failing being called from another machine.
Changed it to `/users` so service must be hosted on same web server as React app.

Refs #77